### PR TITLE
feat: implement hamburger menu for mobile navigation

### DIFF
--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -1,9 +1,9 @@
 import type * as types from 'notion-types'
+import { IoMdClose } from '@react-icons/all-files/io/IoMdClose'
+import { IoMdMenu } from '@react-icons/all-files/io/IoMdMenu'
 import cs from 'classnames'
 import * as React from 'react'
 import { Breadcrumbs, Header, Search, useNotionContext } from 'react-notion-x'
-import { IoMdMenu } from '@react-icons/all-files/io/IoMdMenu'
-import { IoMdClose } from '@react-icons/all-files/io/IoMdClose'
 
 import { isSearchEnabled, navigationLinks, navigationStyle } from '@/lib/config'
 

--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -2,6 +2,8 @@ import type * as types from 'notion-types'
 import cs from 'classnames'
 import * as React from 'react'
 import { Breadcrumbs, Header, Search, useNotionContext } from 'react-notion-x'
+import { IoMdMenu } from '@react-icons/all-files/io/IoMdMenu'
+import { IoMdClose } from '@react-icons/all-files/io/IoMdClose'
 
 import { isSearchEnabled, navigationLinks, navigationStyle } from '@/lib/config'
 
@@ -13,6 +15,7 @@ export function NotionPageHeader({
   block: types.CollectionViewPageBlock | types.PageBlock
 }) {
   const { components, mapPageUrl } = useNotionContext()
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false)
 
   if (navigationStyle === 'default') {
     return <Header block={block} />
@@ -24,37 +27,93 @@ export function NotionPageHeader({
         <Breadcrumbs block={block} rootOnly={true} />
 
         <div className='notion-nav-header-rhs breadcrumbs'>
-          {navigationLinks
-            ?.map((link, index) => {
-              if (!link?.pageId && !link?.url) {
-                return null
-              }
+          {/* Mobile: Search first, then hamburger */}
+          {isSearchEnabled && (
+            <div className={styles.mobileSearch}>
+              <Search block={block} title={null} />
+            </div>
+          )}
 
-              if (link.pageId) {
-                return (
-                  <components.PageLink
-                    href={mapPageUrl(link.pageId)}
-                    key={index}
-                    className={cs(styles.navLink, 'breadcrumb', 'button')}
-                  >
-                    {link.title}
-                  </components.PageLink>
-                )
-              } else {
-                return (
-                  <components.Link
-                    href={link.url}
-                    key={index}
-                    className={cs(styles.navLink, 'breadcrumb', 'button')}
-                  >
-                    {link.title}
-                  </components.Link>
-                )
-              }
-            })
-            .filter(Boolean)}
+          {/* Hamburger menu button (mobile only) */}
+          <button
+            className={styles.hamburgerButton}
+            onClick={() => setIsMenuOpen(!isMenuOpen)}
+            aria-label='Toggle menu'
+          >
+            {isMenuOpen ? <IoMdClose /> : <IoMdMenu />}
+          </button>
 
-          {isSearchEnabled && <Search block={block} title={null} />}
+          {/* Desktop: Navigation links then search */}
+          <div className={cs(styles.desktopNav, 'breadcrumbs')}>
+            {navigationLinks
+              ?.map((link, index) => {
+                if (!link?.pageId && !link?.url) {
+                  return null
+                }
+
+                if (link.pageId) {
+                  return (
+                    <components.PageLink
+                      href={mapPageUrl(link.pageId)}
+                      key={index}
+                      className={cs(styles.navLink, 'breadcrumb', 'button')}
+                    >
+                      {link.title}
+                    </components.PageLink>
+                  )
+                } else {
+                  return (
+                    <components.Link
+                      href={link.url}
+                      key={index}
+                      className={cs(styles.navLink, 'breadcrumb', 'button')}
+                    >
+                      {link.title}
+                    </components.Link>
+                  )
+                }
+              })
+              .filter(Boolean)}
+
+            {isSearchEnabled && <Search block={block} title={null} />}
+          </div>
+
+          {/* Mobile menu dropdown */}
+          {isMenuOpen && (
+            <div className={styles.mobileMenu}>
+              {navigationLinks
+                ?.map((link, index) => {
+                  if (!link?.pageId && !link?.url) {
+                    return null
+                  }
+
+                  if (link.pageId) {
+                    return (
+                      <components.PageLink
+                        href={mapPageUrl(link.pageId)}
+                        key={index}
+                        className={cs(styles.mobileNavLink, 'breadcrumb', 'button')}
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        {link.title}
+                      </components.PageLink>
+                    )
+                  } else {
+                    return (
+                      <components.Link
+                        href={link.url}
+                        key={index}
+                        className={cs(styles.mobileNavLink, 'breadcrumb', 'button')}
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        {link.title}
+                      </components.Link>
+                    )
+                  }
+                })
+                .filter(Boolean)}
+            </div>
+          )}
         </div>
       </div>
     </header>

--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -92,7 +92,11 @@ export function NotionPageHeader({
                       <components.PageLink
                         href={mapPageUrl(link.pageId)}
                         key={index}
-                        className={cs(styles.mobileNavLink, 'breadcrumb', 'button')}
+                        className={cs(
+                          styles.mobileNavLink,
+                          'breadcrumb',
+                          'button'
+                        )}
                         onClick={() => setIsMenuOpen(false)}
                       >
                         {link.title}
@@ -103,7 +107,11 @@ export function NotionPageHeader({
                       <components.Link
                         href={link.url}
                         key={index}
-                        className={cs(styles.mobileNavLink, 'breadcrumb', 'button')}
+                        className={cs(
+                          styles.mobileNavLink,
+                          'breadcrumb',
+                          'button'
+                        )}
                         onClick={() => setIsMenuOpen(false)}
                       >
                         {link.title}

--- a/components/styles.module.css
+++ b/components/styles.module.css
@@ -219,3 +219,88 @@
 .hidden {
   visibility: hidden;
 }
+
+/* Hamburger menu button - hidden on desktop */
+.hamburgerButton {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  font-size: 24px;
+  color: var(--fg-color);
+  align-items: center;
+  justify-content: center;
+}
+
+/* Mobile search - hidden on desktop */
+.mobileSearch {
+  display: none;
+}
+
+/* Desktop navigation - visible on desktop */
+.desktopNav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Mobile menu dropdown */
+.mobileMenu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: var(--bg-color);
+  border: 1px solid var(--fg-color-1);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 8px;
+  min-width: 200px;
+  z-index: 1000;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mobileNavLink {
+  display: block;
+  padding: 12px 16px;
+  text-align: left;
+  width: 100%;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.mobileNavLink:hover {
+  background-color: var(--bg-color-1);
+}
+
+/* Mobile styles - adjust breakpoint as needed (768px is common for mobile/tablet) */
+@media only screen and (max-width: 768px) {
+  /* Hide desktop navigation */
+  .desktopNav {
+    display: none;
+  }
+
+  /* Show mobile search */
+  .mobileSearch {
+    display: flex;
+    order: 1;
+  }
+
+  /* Show hamburger button */
+  .hamburgerButton {
+    display: flex;
+    order: 2;
+  }
+
+  /* Show mobile menu when open */
+  .mobileMenu {
+    display: flex;
+  }
+
+  /* Ensure the parent container allows proper positioning */
+  .notion-nav-header-rhs {
+    position: relative;
+  }
+}


### PR DESCRIPTION
Fixes #1

Implements hamburger menu for mobile navigation as requested:

- Add hamburger menu icon that appears on mobile (width <= 768px)
- Swap order: Search appears before hamburger button on mobile
- Desktop view remains unchanged with navigation links then search
- Mobile menu dropdown shows navigation links when hamburger is clicked
- State management for menu toggle with React useState
- Responsive CSS with proper mobile breakpoints

Generated with [Claude Code](https://claude.ai/code)